### PR TITLE
Publish the Warewulf charter

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,10 +14,19 @@ module.exports = {
         name: `images`,
         path: `${__dirname}/src/images`,
       },
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `posts`,
         path: `${__dirname}/src/posts`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `static-pages`,
+        path: `${__dirname}/src/static-pages`,
       },
     },
     `gatsby-transformer-remark`,

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -7,6 +7,7 @@ const Footer = () => {
       { name: 'Home', href: '/' },
       { name: 'News', href: '/news' },
       { name: 'Getting Help', href: '/help' },
+      { name: 'Charter', href: '/charter' },
       { name: 'Contact', href: '/contact' },
     ],
   }

--- a/src/posts/charter.md
+++ b/src/posts/charter.md
@@ -1,0 +1,29 @@
+---
+slug: "/news/charter-2023-10-11"
+date: "2023-10-11"
+title: "Warewulf Project Charter Published"
+---
+
+The Warewulf Project is pleased to announce the publication of its
+[Project Charter](/charter), and the formation of the Warewulf
+Technical Steering Committee (TSC).
+
+The members of the Technical Steering Committee are drawn from the
+active members of its community and stakeholders:
+
+- Greg Kurtzer, project founder and CIO of CIQ, Inc.
+- Jonathon Anderson, Solutions Architect at CIQ, Inc.
+- Christian Goll, Software Engineer at SUSE, Inc.
+- Jeremy Siadal, HPC Systems Engineer at Intel, Inc. and representing
+  OpenHPC
+- John Hanks, HPC Principal Engineer at Chan Zuckerburg Biohub
+
+We're excited for this next chapter of the Warewulf project, and for
+new opportunities for collaboration in development, community
+management, and advocacy.
+
+If you're interested in being a part of the Warewulf project, please
+[get in touch with us](/help) on Slack, the mailing list, or even just
+by opening an issue or pull request! We look forward to working
+together to continue building the best HPC cluster management solution
+available.

--- a/src/static-pages/charter.md
+++ b/src/static-pages/charter.md
@@ -1,0 +1,204 @@
+---
+slug: /charter
+title: Warewulf Project Charter
+---
+
+This Charter sets forth the responsibilities and procedures for
+technical contribution to, and oversight of, the Warewulf open source
+project (the “Project”). All contributors (including committers,
+maintainers, and other technical positions) and other participants in
+the Project (collectively, “Collaborators”) must comply with the terms
+of this Charter.
+
+## 1. Mission and Scope of the Project
+
+1. The mission of the Project is to maintain and enhance the source
+   code of the Warewulf open source container platform.
+
+2. The scope of the Project includes collaborative development under
+   the Project License (as defined herein) supporting the mission,
+   including documentation, testing, integration and the creation of
+   other artifacts that aid the development, deployment, operation or
+   adoption of the open source project.
+
+## 2. Technical Steering Committee
+
+1. The Technical Steering Committee (the "TSC") will be responsible
+   for all technical oversight of the open source Project.
+
+2. At the inception of the project, the Committers of the Project will
+   be as set forth within the "CONTRIBUTING" file within the Project's
+   code repository. The TSC may choose an alternative approach for
+   determining the voting members of the TSC, and any such alternative
+   approach will be documented in the CONTRIBUTING file. Any meetings
+   of the Technical Steering Committee are intended to be open to the
+   public, and can be conducted electronically, via teleconference, or
+   in person.
+
+3. TSC projects generally will involve Contributors and
+   Committers. The TSC may adopt or modify roles so long as the roles
+   are documented in the CONTRIBUTING file. Unless otherwise
+   documented:
+
+   1. Contributors include anyone in the technical community that
+      contributes code, documentation, or other technical artifacts to
+      the Project.
+
+   2. Committers are Contributors who have earned the ability to
+      modify ("commit") source code, documentation or other technical
+      artifacts in a project's repository; and
+
+   3. A Contributor may become a Committer by a majority approval of
+      the existing Committers. A Committer may be removed by a
+      majority approval of the other existing Committers.
+
+4. Participation in the Project through becoming a Contributor and
+   Committer is open to anyone so long as they abide by the terms of
+   this Charter.
+
+5. The TSC may (1) establish work flow procedures for the submission,
+   approval, and closure/archiving of projects, (2) set requirements
+   for the promotion of Contributors to Committer status, as
+   applicable, and (3) amend, adjust, refine and/or eliminate the
+   roles of Contributors, and Committers, and create new roles, and
+   publicly document any TSC roles, as it sees fit.
+
+6. The TSC may elect a TSC Chair, who will preside over meetings of
+   the TSC and will serve until their resignation or replacement by
+   the TSC.
+
+7. Responsibilities: The TSC will be responsible for all aspects of
+   oversight relating to the Project, which may include:
+
+   1. coordinating the technical direction of the Project;
+
+   2. approving project or system proposals (including, but not
+      limited to, incubation, deprecation, and changes to a
+      sub-project's scope);
+
+   3. organizing sub-projects and removing sub-projects;
+
+   4. creating sub-committees or working groups to focus on
+      cross-project technical issues and requirements;
+
+   5. appointing representatives to work with other open source or
+      open standards communities;
+
+   6. establishing community norms, workflows, issuing releases, and
+      security reporting policies;
+
+   7. approving and implementing policies and processes for
+      contributing (to be published in the CONTRIBUTING file) and
+      resolving matters or concerns that may arise as set forth in
+      Section 6 of this Charter;
+
+   8. discussions, seeking consensus, and where necessary, voting on
+      technical matters relating to the code base that affect multiple
+      projects; and
+
+   9. coordinating any marketing, events, or communications regarding
+      the Project.
+
+## 3. TSC Voting
+
+1. While the Project aims to operate as a consensus-based community,
+   if any TSC decision requires a vote to move the Project forward,
+   the voting members of the TSC will vote on a one vote per voting
+   member basis.
+
+2. Quorum for TSC meetings requires at least fifty percent of all
+   voting members of the TSC to be present. The TSC may continue to
+   meet if quorum is not met but will be prevented from making any
+   decisions at the meeting.
+
+3. Except as provided in Section 6.3. and 7.1., decisions by vote at a
+   meeting require a majority vote of those in attendance, provided
+   quorum is met. Decisions made by electronic vote without a meeting
+   require a majority vote of all voting members of the TSC.
+
+## 4. Compliance with Policies
+
+1. When amending or adopting any policy applicable to the Project, the
+   Project will publish such policy, as to be amended or adopted, on
+   its web site at least 30 days prior to such policy taking effect.
+
+2. All Collaborators must allow open participation from any individual
+   or organization meeting the requirements for contributing under
+   this Charter and any policies adopted for all Collaborators by the
+   TSC, regardless of competitive interests. Put another way, the
+   Project community must not seek to exclude any participant based on
+   any criteria, requirement, or reason other than those that are
+   reasonable and applied on a non-discriminatory basis to all
+   Collaborators in the Project community.
+
+3. The Project will operate in a transparent, open, collaborative, and
+   ethical manner at all times. The output of all Project discussions,
+   proposals, timelines, decisions, and status should be made open and
+   easily visible to all.
+
+## 5. General Rules and Operations
+
+1. The Project will:
+
+   1. engage in the work of the Project in a professional manner
+      consistent with maintaining a cohesive community; and
+
+   2. respect the rights of all trademark owners, including any
+      branding and trademark usage guidelines.
+
+## 6. Intellectual Property Policy
+
+1. Collaborators acknowledge that the copyright in all new
+   contributions will be retained by the copyright holder as
+   independent works of authorship and that no contributor or
+   copyright holder will be required to assign copyright to the
+   Project.
+
+2. Except as described in Section 6.3., all contributions to the
+   Project are subject to the following:
+
+   1. All new inbound code contributions to the Project must be made
+      using the 3-clause BSD License (the "Project License").
+
+   2. All new inbound code contributions must also be accompanied by a
+      Developer Certificate of Origin
+      (http://developercertificate.org) sign-off in the source code
+      system that is submitted through a TSC-approved contribution
+      process which will bind the authorized contributor and, if not
+      self-employed, their employer to the applicable license;
+
+   3. All outbound code will be made available under the Project
+      License.
+
+   4. Documentation will be received and made available by the Project
+      under the Creative Commons Attribution 4.0 International License
+      (available at http://creativecommons.org/licenses/by/4.0/).
+
+   5. To the extent a contribution includes or consists of data, any
+      rights in such data shall be made available under the
+      CDLA-Permissive 2.0 License, available at
+      https://cdla.dev/permissive-2.0.
+
+   6. The Project may seek to integrate and contribute back to other
+      open source projects ("Upstream Projects"). In such cases, the
+      Project will conform to all license requirements of the Upstream
+      Projects, including dependencies, leveraged by the
+      Project. Upstream Project code contributions not stored within
+      the Project's main code repository will comply with the
+      contribution process and license terms for the applicable
+      Upstream Project.
+
+3. The TSC may approve the use of an alternative license or licenses
+   for inbound or outbound contributions on an exception basis. To
+   request an exception, please describe the contribution, the
+   alternative open source license(s), and the justification for using
+   an alternative open source license for the Project. License
+   exceptions must be approved by a two-thirds vote of the entire TSC.
+
+4. Contributed files should contain license information, such as SPDX
+   short form identifiers, indicating the open source license or
+   licenses pertaining to the file.
+
+## 7. Amendments
+
+1. This charter may be amended by a two-thirds vote of the entire TSC.


### PR DESCRIPTION
The Warewulf project is organizing under the included charter. Publishing it at warewulf.org and including an announcement.